### PR TITLE
Add dependencies and support gazebo and ros2 control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if(BUILD_TESTING)
 endif()
 
 install(
-  DIRECTORY controller meshes robots urdf
+  DIRECTORY meshes robots urdf
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,13 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
+  <exec_depend>xacro</exec_depend>
+  <exec_depend>urdf</exec_depend>
+  <exec_depend>ros2launch</exec_depend>
+
+  <depend>joint_state_publisher</depend>
+  <depend>joint_state_publisher_gui</depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/robots/robot.urdf.xacro
+++ b/robots/robot.urdf.xacro
@@ -1,24 +1,32 @@
 <?xml version="1.0" ?>
 <robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
-    <xacro:include filename="./../urdf/skratch_base/skratch_top_base.urdf.xacro"/> 
-    <xacro:include filename="./../urdf/skratch_base/skratch_bottom_base.urdf.xacro"/>
-    <xacro:include filename="./../urdf/skratch_base/skratch_wheel_support.urdf.xacro"/>
-    <xacro:include filename="./../urdf/skratch_wheels/skratch_wheel_hub.urdf.xacro"/>
-    <xacro:include filename="./../urdf/skratch_wheels/skratch_wheel.urdf.xacro"/>
+    <xacro:include filename="$(find skratch_description)/urdf/skratch_base/skratch_top_base.urdf.xacro"/> 
+    <xacro:include filename="$(find skratch_description)/urdf/skratch_base/skratch_bottom_base.urdf.xacro"/>
+    <xacro:include filename="$(find skratch_description)/urdf/skratch_base/skratch_wheel_support.urdf.xacro"/>
+    <xacro:include filename="$(find skratch_description)/urdf/skratch_wheels/skratch_wheel_hub.urdf.xacro"/>
+    <xacro:include filename="$(find skratch_description)/urdf/skratch_wheels/skratch_wheel.urdf.xacro"/>
+    <xacro:include filename="$(find skratch_description)/urdf/skratch_macro.ros2_control.xacro" />
 
-    <link name="base_link">
+    <xacro:arg name="robot_name" default=""/>                   <!-- used by the launch system -->
+    <xacro:arg name="sim_gazebo" default="false"/>              <!-- used by the launch system (gazebo "classic")-->
+    <xacro:arg name="sim_gz" default="false"/>                  <!-- used by the launch system (latest version of gazebo) -->
+    <xacro:arg name="controllers" default=""/>                  <!-- used by the launch system -->
+    <xacro:property name="namespace" default="$(arg robot_name)"/>
+    <xacro:property name="prefix" default="${namespace}_" />
+
+    <link name="${prefix}base_link">
     </link>
     <xacro:skratch_top_base name="left_skratch_top_base"/>
     <joint name="base_joint" type="fixed">
         <origin xyz="0.0 -0.005 0.0" rpy="0.0 0.0 0.0"/>
-        <parent link="base_link"/>
+        <parent link="${prefix}base_link"/>
         <child link="left_skratch_top_base"/>
     </joint>
 
     <xacro:skratch_top_base name="right_skratch_top_base"/>
     <joint name="frame_joint" type="fixed">
         <origin xyz="0.0 0.003 0.0" rpy="0.0 0.0 3.14"/>
-        <parent link="base_link"/>
+        <parent link="${prefix}base_link"/>
         <child link="right_skratch_top_base"/>
     </joint>
 
@@ -145,5 +153,30 @@
         <child link="rear_right_wheel_two"/>
         <axis xyz="0.0 1.0 0.0"/>
     </joint>
+
+
+    <xacro:if value="$(arg sim_gazebo)">
+        <xacro:macro_ros2_control name="GazeboSystem" plugin="gazebo_ros2_control/GazeboSystem"/>
+        <gazebo>
+            <plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">
+                <parameters>$(arg controllers)</parameters>
+                <ros>
+                    <namespace>${namespace}</namespace>
+                </ros>
+            </plugin>
+        </gazebo>
+    </xacro:if>
+
+    <xacro:if value="$(arg sim_gz)">
+        <xacro:macro_ros2_control name="IgnitionSystem" plugin="ign_ros2_control/IgnitionSystem"/>
+        <gazebo>
+            <plugin filename="ign_ros2_control-system" name="ign_ros2_control::IgnitionROS2ControlPlugin">
+                <parameters>$(arg controllers)</parameters>
+                <ros>
+                    <namespace>${namespace}</namespace>
+                </ros>
+            </plugin>
+        </gazebo>
+    </xacro:if>
 
 </robot>

--- a/urdf/skratch_base/skratch_bottom_base.urdf.xacro
+++ b/urdf/skratch_base/skratch_bottom_base.urdf.xacro
@@ -10,13 +10,13 @@
             <visual>
                 <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
                 <geometry>
-                    <mesh filename="package://skratch_description/meshes/skratch_base/skratch_bottom_base.stl" scale="0.001 0.001 0.001"/>
+                    <mesh filename="file://$(find skratch_description)/meshes/skratch_base/skratch_bottom_base.stl" scale="0.001 0.001 0.001"/>
                 </geometry>
             </visual>
             <collision>
                 <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
                 <geometry>
-                    <mesh filename="package://skratch_description/meshes/skratch_base/skratch_bottom_base.stl" scale="0.001 0.001 0.001"/>
+                    <mesh filename="file://$(find skratch_description)/meshes/skratch_base/skratch_bottom_base.stl" scale="0.001 0.001 0.001"/>
                 </geometry>
             </collision>
         </link>

--- a/urdf/skratch_base/skratch_top_base.urdf.xacro
+++ b/urdf/skratch_base/skratch_top_base.urdf.xacro
@@ -10,13 +10,13 @@
             <visual>
                 <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
                 <geometry>
-                    <mesh filename="package://skratch_description/meshes/skratch_base/skratch_top_base.stl" scale="0.001 0.001 0.001"/>
+                    <mesh filename="file://$(find skratch_description)/meshes/skratch_base/skratch_top_base.stl" scale="0.001 0.001 0.001"/>
                 </geometry>
             </visual>
             <collision>
                 <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
                 <geometry>
-                    <mesh filename="package://skratch_description/meshes/skratch_base/skratch_top_base.stl" scale="0.001 0.001 0.001"/>
+                    <mesh filename="file://$(find skratch_description)/meshes/skratch_base/skratch_top_base.stl" scale="0.001 0.001 0.001"/>
                 </geometry>
             </collision>
         </link>

--- a/urdf/skratch_base/skratch_wheel_support.urdf.xacro
+++ b/urdf/skratch_base/skratch_wheel_support.urdf.xacro
@@ -10,13 +10,13 @@
             <visual>
                 <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
                 <geometry>
-                    <mesh filename="package://skratch_description/meshes/skratch_base/skratch_wheel_support.stl" scale="0.001 0.001 0.001"/>
+                    <mesh filename="file://$(find skratch_description)/meshes/skratch_base/skratch_wheel_support.stl" scale="0.001 0.001 0.001"/>
                 </geometry>
             </visual>
             <collision>
                 <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
                 <geometry>
-                    <mesh filename="package://skratch_description/meshes/skratch_base/skratch_wheel_support.stl" scale="0.001 0.001 0.001"/>
+                    <mesh filename="file://$(find skratch_description)/meshes/skratch_base/skratch_wheel_support.stl" scale="0.001 0.001 0.001"/>
                 </geometry>
             </collision>
         </link>

--- a/urdf/skratch_macro.ros2_control.xacro
+++ b/urdf/skratch_macro.ros2_control.xacro
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+    <xacro:macro name="macro_ros2_control" params="name plugin">
+        <ros2_control name="${name}" type="system">
+            <hardware>
+                <plugin>${plugin}</plugin>
+            </hardware>
+            <joint name="rear_left_skratch_wheel_hub_joint">
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="rear_left_wheel_one_joint">
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="rear_left_wheel_two_joint">
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="rear_right_skratch_wheel_hub_joint">
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="rear_right_wheel_one_joint">
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="rear_right_wheel_two_joint">
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="front_left_skratch_wheel_hub_joint">
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="front_left_wheel_one_joint">
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="front_left_wheel_two_joint">
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="front_right_skratch_wheel_hub_joint">
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="front_right_wheel_one_joint">
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="front_right_wheel_two_joint">
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+        </ros2_control>
+    </xacro:macro>
+</robot>

--- a/urdf/skratch_wheels/skratch_wheel.urdf.xacro
+++ b/urdf/skratch_wheels/skratch_wheel.urdf.xacro
@@ -10,13 +10,13 @@
             <visual>
                 <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
                 <geometry>
-                    <mesh filename="package://skratch_description/meshes/skratch_wheel/kelo_drive_wheel.stl" scale="1 1 1"/>
+                    <mesh filename="file://$(find skratch_description)/meshes/skratch_wheel/kelo_drive_wheel.stl" scale="1 1 1"/>
                 </geometry>
             </visual>
             <collision>
                 <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
                 <geometry>
-                    <mesh filename="package://skratch_description/meshes/skratch_wheel/kelo_drive_wheel.stl" scale="1 1 1"/>
+                    <mesh filename="file://$(find skratch_description)/meshes/skratch_wheel/kelo_drive_wheel.stl" scale="1 1 1"/>
                 </geometry>
             </collision>
         </link>

--- a/urdf/skratch_wheels/skratch_wheel_hub.urdf.xacro
+++ b/urdf/skratch_wheels/skratch_wheel_hub.urdf.xacro
@@ -10,13 +10,13 @@
             <visual>
                 <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
                 <geometry>
-                    <mesh filename="package://skratch_description/meshes/skratch_wheel/kelo_drive_base.stl" scale="1 1 1"/>
+                    <mesh filename="file://$(find skratch_description)/meshes/skratch_wheel/kelo_drive_base.stl" scale="1 1 1"/>
                 </geometry>
             </visual>
             <collision>
                 <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
                 <geometry>
-                    <mesh filename="package://skratch_description/meshes/skratch_wheel/kelo_drive_base.stl" scale="1 1 1"/>
+                    <mesh filename="file://$(find skratch_description)/meshes/skratch_wheel/kelo_drive_base.stl" scale="1 1 1"/>
                 </geometry>
             </collision>
         </link>


### PR DESCRIPTION
- [x] dependencies have been added to the `package.xml` so that `rosdep` can take care of installing them properly.
- [x] removed unknown folders on the `CMakeLists.txt`
- [x] add xacro macro for `ros2_control` tag
- [x] add support for simulation with Gazebo "classic" and Gazebo Fortress